### PR TITLE
Fret testing and development

### DIFF
--- a/packages/db-p2p/src/fret/cohort.ts
+++ b/packages/db-p2p/src/fret/cohort.ts
@@ -1,0 +1,36 @@
+import type { PeerId } from '@libp2p/interface'
+import { xorDistance, coordOfPeer, lessLex } from './ring.js'
+
+export type CohortResult = { anchors: [PeerId, PeerId], cohort: PeerId[] }
+
+export function assembleTwoSidedCohort(
+	key: Uint8Array,
+	peers: PeerId[],
+	wants: number
+): CohortResult {
+	if (peers.length === 0) return { anchors: [undefined as unknown as PeerId, undefined as unknown as PeerId], cohort: [] }
+	const distances = peers.map(p => ({ p, d: xorDistance(coordOfPeer(p), key) }))
+	distances.sort((a, b) => (lessLex(a.d, b.d) ? -1 : 1))
+	const succ = distances[0]!.p
+	const pred = distances[1]?.p ?? succ
+	const anchors: [PeerId, PeerId] = [succ, pred]
+
+	const sorted = distances.map(x => x.p)
+	const cohort: PeerId[] = []
+	let i = 0
+	let lo = sorted.indexOf(succ)
+	let hi = sorted.indexOf(pred)
+	if (hi < 0) hi = lo
+	while (cohort.length < wants && (lo >= 0 || hi < sorted.length)) {
+		if (i % 2 === 0) {
+			if (lo >= 0) cohort.push(sorted[lo]!)
+			--lo
+		} else {
+			if (hi < sorted.length) cohort.push(sorted[hi]!)
+			++hi
+		}
+		++i
+	}
+	return { anchors, cohort }
+}
+

--- a/packages/db-p2p/src/fret/ring.ts
+++ b/packages/db-p2p/src/fret/ring.ts
@@ -1,0 +1,37 @@
+import type { PeerId } from '@libp2p/interface'
+
+export type RingCoord = Uint8Array
+
+export function xorDistance(a: Uint8Array, b: Uint8Array): Uint8Array {
+	const len = Math.max(a.length, b.length)
+	const out = new Uint8Array(len)
+	for (let i = 0; i < len; i++) {
+		const ai = a[a.length - 1 - i] ?? 0
+		const bi = b[b.length - 1 - i] ?? 0
+		out[len - 1 - i] = ai ^ bi
+	}
+	return out
+}
+
+export function lessLex(a: Uint8Array, b: Uint8Array): boolean {
+	const len = Math.max(a.length, b.length)
+	for (let i = 0; i < len; i++) {
+		const av = a[i] ?? 0
+		const bv = b[i] ?? 0
+		if (av < bv) return true
+		if (av > bv) return false
+	}
+	return false
+}
+
+export function coordOfPeer(peerId: PeerId): RingCoord {
+	return peerId.toMultihash().bytes
+}
+
+export function sortByDistanceTo(target: Uint8Array, coords: Array<{ id: PeerId }>): Array<{ id: PeerId }>{
+	return coords
+		.map(p => ({ p, d: xorDistance(coordOfPeer(p.id), target) }))
+		.sort((a, b) => (lessLex(a.d, b.d) ? -1 : 1))
+		.map(x => x.p)
+}
+

--- a/packages/db-p2p/src/fret/service.ts
+++ b/packages/db-p2p/src/fret/service.ts
@@ -1,0 +1,81 @@
+import type { Startable, Logger, PeerId } from '@libp2p/interface'
+import { assembleTwoSidedCohort } from './cohort.js'
+
+type Components = {
+	logger: { forComponent: (name: string) => Logger }
+	registrar: { handle: (...args: any[]) => Promise<void>, unhandle: (...args: any[]) => Promise<void> }
+}
+
+export type FretServiceInit = {
+	clusterSize?: number
+}
+
+export class FretService implements Startable {
+	private running = false
+	private readonly log: Logger
+	private readonly k: number
+	private libp2pRef: any | undefined
+
+	constructor(private readonly components: Components, init: FretServiceInit = {}) {
+		this.log = components.logger.forComponent('db-p2p:fret')
+		this.k = Math.max(1, init.clusterSize ?? 10)
+	}
+
+	setLibp2p(libp2p: any): void { this.libp2pRef = libp2p }
+
+	private getLibp2p(): any {
+		try {
+			return this.libp2pRef ?? (this.components as any).libp2p
+		} catch {
+			return this.libp2pRef
+		}
+	}
+
+	get [Symbol.toStringTag](): string { return '@libp2p/fret' }
+
+	async start(): Promise<void> {
+		if (this.running) return
+		// Ensure we hold a stable reference to libp2p instance as early as possible
+		try { ((this.components as any).libp2p?.services?.fret as any)?.setLibp2p?.((this.components as any).libp2p) } catch {}
+		this.running = true
+	}
+
+	async stop(): Promise<void> {
+		this.running = false
+	}
+
+	private getKnownPeers(): PeerId[] {
+		try {
+			const libp2p = this.getLibp2p()
+			const selfId: PeerId = libp2p.peerId
+			const storePeers: Array<{ id: PeerId }> = libp2p.peerStore.getPeers() ?? []
+			const connPeers: PeerId[] = (libp2p.getConnections?.() ?? []).map((c: any) => c.remotePeer)
+			const all = [...storePeers.map(p => p.id), ...connPeers]
+			const uniq = all.filter((p, i) => all.findIndex(x => x.toString() === p.toString()) === i)
+			return uniq.filter((pid: PeerId) => pid.toString() !== selfId.toString())
+		} catch {
+			return []
+		}
+	}
+
+	async getCluster(key: Uint8Array): Promise<PeerId[]> {
+		const libp2p = this.getLibp2p()
+		if (!libp2p?.peerId) return []
+		const peers: PeerId[] = [libp2p.peerId, ...this.getKnownPeers()]
+		const wants = Math.min(this.k, peers.length)
+		if (wants === 0) return []
+		const { cohort } = assembleTwoSidedCohort(key, peers, wants)
+		return cohort
+	}
+
+	async isInCluster(key: Uint8Array): Promise<boolean> {
+		const libp2p = this.getLibp2p()
+		const cluster = await this.getCluster(key)
+		return cluster.some(p => p.toString() === libp2p.peerId.toString())
+	}
+}
+
+export function fretService(init: FretServiceInit = {}) {
+	return (components: Components) => new FretService(components, init)
+}
+

--- a/packages/db-p2p/src/index.ts
+++ b/packages/db-p2p/src/index.ts
@@ -19,5 +19,8 @@ export * from "./routing/responsibility.js";
 export * from "./routing/libp2p-known-peers.js";
 export * from "./network/network-manager-service.js";
 export * from "./network/get-network-manager.js";
+export * from "./fret/service.js";
+export * from "./fret/ring.js";
+export * from "./fret/cohort.js";
 
 

--- a/packages/db-p2p/src/network/get-network-manager.ts
+++ b/packages/db-p2p/src/network/get-network-manager.ts
@@ -1,5 +1,7 @@
 import type { Libp2p } from 'libp2p'
 import type { NetworkManagerService } from './network-manager-service.js'
+import type { IPeerNetwork } from '@optimystic/db-core'
+import type { PeerId } from '@libp2p/interface'
 
 export function getNetworkManager(node: Libp2p): NetworkManagerService {
   const svc = (node as any).services?.networkManager
@@ -9,6 +11,14 @@ export function getNetworkManager(node: Libp2p): NetworkManagerService {
   // Provide libp2p reference early to avoid MissingServiceError from components accessor
   try { (svc as any).setLibp2p?.(node) } catch {}
   return svc as NetworkManagerService
+}
+
+export function getPeerNetwork(node: Libp2p): IPeerNetwork {
+  return {
+    async connect(peerId: PeerId, protocol: string, options?: any) {
+      return await node.dialProtocol(peerId, protocol, options)
+    }
+  }
 }
 
 

--- a/packages/db-p2p/src/repo/service.ts
+++ b/packages/db-p2p/src/repo/service.ts
@@ -112,14 +112,15 @@ export class RepoService implements Startable {
             // Use sha256 digest of block id string for consistent key space
             const mh = await sha256.digest(new TextEncoder().encode(operation.get.blockIds[0]!))
             const key = mh.digest
+            const fret: any = (this.components as any).libp2p?.services?.fret
             const nm: any = (this.components as any).libp2p?.services?.networkManager
-            if (nm?.getCluster) {
-              const cluster: any[] = await nm.getCluster(key)
+            if (fret?.getCluster || nm?.getCluster) {
+              const cluster: any[] = fret?.getCluster ? await fret.getCluster(key) : await nm.getCluster(key)
               ;(message as any).cluster = (cluster as any[]).map(p => p.toString?.() ?? String(p))
               const selfId = (this.components as any).libp2p.peerId
               const isMember = cluster.some((p: any) => peersEqual(p, selfId))
               if (!isMember) {
-                const peers = cluster.filter((p: any) => !peersEqual(p, selfId))
+                const peers = cluster.filter((p: any) => !peersEqual(p, selfId) && !peersEqual(p, peerId))
                 response = encodePeers(peers.map((pid: any) => ({ id: pid.toString(), addrs: [] })))
               } else {
                 response = await this.repo.get(operation.get, { expiration: message.expiration })
@@ -133,14 +134,15 @@ export class RepoService implements Startable {
             const id = Object.keys(operation.pend.transforms)[0]!
             const mh = await sha256.digest(new TextEncoder().encode(id))
             const key = mh.digest
+            const fret: any = (this.components as any).libp2p?.services?.fret
             const nm: any = (this.components as any).libp2p?.services?.networkManager
-            if (nm?.getCluster) {
-              const cluster: any[] = await nm.getCluster(key)
+            if (fret?.getCluster || nm?.getCluster) {
+              const cluster: any[] = fret?.getCluster ? await fret.getCluster(key) : await nm.getCluster(key)
               ;(message as any).cluster = (cluster as any[]).map(p => p.toString?.() ?? String(p))
               const selfId = (this.components as any).libp2p.peerId
               const isMember = cluster.some((p: any) => peersEqual(p, selfId))
               if (!isMember) {
-                const peers = cluster.filter((p: any) => !peersEqual(p, selfId))
+                const peers = cluster.filter((p: any) => !peersEqual(p, selfId) && !peersEqual(p, peerId))
                 response = encodePeers(peers.map((pid: any) => ({ id: pid.toString(), addrs: [] })))
               } else {
                 response = await this.repo.pend(operation.pend, { expiration: message.expiration })
@@ -157,14 +159,15 @@ export class RepoService implements Startable {
           {
             const mh = await sha256.digest(new TextEncoder().encode(operation.commit.tailId))
             const key = mh.digest
+            const fret: any = (this.components as any).libp2p?.services?.fret
             const nm: any = (this.components as any).libp2p?.services?.networkManager
-            if (nm?.getCluster) {
-              const cluster: any[] = await nm.getCluster(key)
+            if (fret?.getCluster || nm?.getCluster) {
+              const cluster: any[] = fret?.getCluster ? await fret.getCluster(key) : await nm.getCluster(key)
               ;(message as any).cluster = (cluster as any[]).map(p => p.toString?.() ?? String(p))
               const selfId = (this.components as any).libp2p.peerId
               const isMember = cluster.some((p: any) => peersEqual(p, selfId))
               if (!isMember) {
-                const peers = cluster.filter((p: any) => !peersEqual(p, selfId))
+                const peers = cluster.filter((p: any) => !peersEqual(p, selfId) && !peersEqual(p, peerId))
                 response = encodePeers(peers.map((pid: any) => ({ id: pid.toString(), addrs: [] })))
               } else {
                 response = await this.repo.commit(operation.commit, { expiration: message.expiration })

--- a/packages/db-p2p/test/fret.mesh.sizes.spec.ts
+++ b/packages/db-p2p/test/fret.mesh.sizes.spec.ts
@@ -1,0 +1,74 @@
+import { expect } from 'aegir/chai'
+import { createLibp2pNode } from '../src/libp2p-node.js'
+import { RepoClient } from '../src/index.js'
+import { multiaddr } from '@multiformats/multiaddr'
+import { sha256 } from 'multiformats/hashes/sha2'
+
+async function startMesh(n: number, basePort: number, clusterSize: number) {
+  const nodes: any[] = []
+  for (let i = 0; i < n; i++) {
+    const node = await createLibp2pNode({ port: basePort + i, bootstrapNodes: [], networkName: 'optimystic-test', dhtClientMode: true, clusterSize })
+    nodes.push(node)
+  }
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < n; j++) {
+      if (i === j) continue
+      await nodes[i].dial(multiaddr(`/ip4/127.0.0.1/tcp/${basePort + j}/p2p/${nodes[j].peerId.toString()}`))
+    }
+  }
+  // Wait until peerStore reflects all peers
+  const start = Date.now()
+  while (Date.now() - start < 3000) {
+    const peers: Array<{ id: any }> = (nodes[0] as any).peerStore.getPeers() ?? []
+    const remotes = peers.filter(p => p.id.toString() !== (nodes[0] as any).peerId.toString())
+    if (remotes.length >= Math.max(0, n - 1)) break
+    await new Promise(r => setTimeout(r, 50))
+  }
+  return nodes
+}
+
+describe('FRET integration - mesh sizes', function () {
+	this.timeout(40000)
+	const basePort = 9111
+	const k = 3
+
+	async function runCase(n: number, blockId: string) {
+		const nodes = await startMesh(n, basePort + n * 10, k)
+		try {
+			const digest = await sha256.digest(new TextEncoder().encode(blockId))
+			const key = digest.digest
+      const fret0: any = (nodes[0] as any).services?.fret
+      let cluster: any[] = []
+      const expected = Math.min(k, n)
+      const t0 = Date.now()
+      while (Date.now() - t0 < 5000) {
+        cluster = fret0 ? await fret0.getCluster(key) : []
+        if (cluster.length >= expected) break
+        await new Promise(r => setTimeout(r, 50))
+      }
+      expect(cluster.length).to.be.at.least(Math.min(1, expected))
+      expect(cluster.length).to.be.at.most(expected)
+			// For single-node, skip RPC (dialing self is invalid); just assert membership
+			if (n === 1) return
+			// Find a non-member if any
+			const nonMemberIdx = nodes.findIndex((nd: any) => !cluster.some((p: any) => p.toString() === nd.peerId.toString()))
+			const clientIdx = nonMemberIdx >= 0 ? nonMemberIdx : 0
+			const targetIdx = clientIdx === 0 ? 1 : 0
+			const client = (RepoClient as any).create(nodes[targetIdx].peerId, (nodes[clientIdx] as any).peerNetwork)
+			const resp = await client.get({ blockIds: [blockId] }, {})
+			if (nonMemberIdx >= 0) {
+				expect('redirect' in resp).to.equal(true)
+				expect(resp.redirect.peers).to.have.length.greaterThan(0)
+			} else {
+				expect('redirect' in resp).to.equal(false)
+			}
+		} finally {
+			await Promise.all(nodes.map((n: any) => n.stop().catch(() => {})))
+		}
+	}
+
+	it('n=1', async () => { await runCase(1, 'block-A') })
+	it('n=2', async () => { await runCase(2, 'block-B') })
+	it('n=5', async () => { await runCase(5, 'block-C') })
+})
+

--- a/packages/db-p2p/test/fret.mesh.spec.ts
+++ b/packages/db-p2p/test/fret.mesh.spec.ts
@@ -1,0 +1,39 @@
+import { expect } from 'aegir/chai'
+import { multiaddr } from '@multiformats/multiaddr'
+import { RepoClient } from '../src/index.js'
+import { createLibp2pNode } from '../src/libp2p-node.js'
+
+async function startMesh(n: number, basePort: number) {
+  const nodes: any[] = []
+  for (let i = 0; i < n; i++) {
+    const node = await createLibp2pNode({ port: basePort + i, bootstrapNodes: [], networkName: 'optimystic-test', dhtClientMode: true, clusterSize: Math.min(3, n) })
+    nodes.push(node)
+  }
+  // Connect all to all for stability in test
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < n; j++) {
+      if (i === j) continue
+      await nodes[i].dial(multiaddr(`/ip4/127.0.0.1/tcp/${basePort + j}/p2p/${nodes[j].peerId.toString()}`))
+    }
+  }
+  return nodes
+}
+
+describe('FRET integration - small mesh cluster redirects', function () {
+  this.timeout(30000)
+  it('non-member receives redirect peers for key affinity', async () => {
+    const nodes = await startMesh(3, 9051)
+    try {
+      const client = (RepoClient as any).create(nodes[0].peerId, (nodes[1] as any).peerNetwork)
+      const resp = await client.get({ blockIds: ['block-1'] }, {})
+      if ('redirect' in resp) {
+        expect(resp.redirect.peers).to.have.length.greaterThan(0)
+      } else {
+        expect(resp).to.exist
+      }
+    } finally {
+      await Promise.all(nodes.map((n: any) => n.stop().catch(() => {})))
+    }
+  })
+})
+

--- a/packages/db-p2p/test/fret.spec.ts
+++ b/packages/db-p2p/test/fret.spec.ts
@@ -1,0 +1,22 @@
+import { expect } from 'aegir/chai'
+import { assembleTwoSidedCohort } from '../src/fret/cohort.js'
+
+function fakePeer(id: string): any {
+	return {
+		toString() { return id },
+		toMultihash() { return { bytes: new TextEncoder().encode(id.padStart(32, '0')).slice(0, 32) } }
+	}
+}
+
+describe('FRET ring/cohort basics', () => {
+	it('orders peers by XOR distance and assembles cohort', () => {
+		const peers = ['a', 'b', 'c', 'd', 'e'].map(fakePeer)
+		const key = new TextEncoder().encode('key-1'.padStart(32, '0')).slice(0, 32)
+		const { anchors, cohort } = assembleTwoSidedCohort(key, peers as any, 3)
+		expect(anchors[0]).to.exist
+		expect(cohort).to.have.lengthOf(3)
+		// Ensure cohort items are from input set
+		cohort.forEach(p => expect(peers.map(x => x.toString())).to.include(p.toString()))
+	})
+})
+

--- a/packages/test-peer/src/index.ts
+++ b/packages/test-peer/src/index.ts
@@ -1,1 +1,2 @@
 export * from './cli.js';
+export * from './mesh.js';


### PR DESCRIPTION
Implement initial FRET service with ring/cohort primitives and integrate into `db-p2p` for cluster selection, along with unit and integration tests.

This PR lays the groundwork for FRET by providing its core components and initial test coverage, enabling further development and debugging as outlined in `fret.md` and `todo.md`.

---
<a href="https://cursor.com/background-agent?bcId=bc-8be57e4c-3c5e-408a-8b85-9209ac73f9e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8be57e4c-3c5e-408a-8b85-9209ac73f9e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

